### PR TITLE
Add html to mailer

### DIFF
--- a/backend/nest-cli.json
+++ b/backend/nest-cli.json
@@ -3,6 +3,12 @@
   "collection": "@nestjs/schematics",
   "sourceRoot": "src",
   "compilerOptions": {
-    "deleteOutDir": true
+    "deleteOutDir": true,
+    "assets": [
+      {
+        "include": "email_content/**/*",
+        "outDir": "dist/"
+      }
+    ]
   }
 }

--- a/backend/src/email_content/signup.html
+++ b/backend/src/email_content/signup.html
@@ -1,0 +1,60 @@
+<!doctype html>
+<html lang="en">
+  <head>
+    <meta charset="UTF-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <link
+      href="https://fonts.googleapis.com/css2?family=Exo:ital,wght@0,100..900;1,100..900&family=Lato:ital,wght@0,100;0,300;0,400;0,700;0,900;1,100;1,300;1,400;1,700;1,900&family=Oxygen:wght@300;400;700&family=Roboto+Slab:wght@100..900&display=swap"
+      rel="stylesheet"
+    />
+  </head>
+  <title>Welcome to Illusia!</title>
+  <style>
+    * {
+      margin: 0;
+      padding: 0;
+    }
+    body {
+      text-align: center;
+      color: #2c2c2c;
+      font-family: Lato, sans-serif;
+    }
+    header {
+      display: flex;
+      flex-direction: column;
+      line-height: 1.3;
+      padding: 1rem;
+      gap: 10px;
+    }
+    h1 {
+      font-size: 32px;
+    }
+    h1 + p {
+      margin-bottom: 10px;
+    }
+    #signup_image {
+      width: 100%;
+    }
+    main {
+      display: flex;
+      text-align: center;
+      flex-direction: column;
+    }
+    a {
+      text-underline-offset: 4px;
+      margin: 0 0 1rem;
+    }
+  </style>
+  <body>
+    <header>
+      <h1>Welcome to Illusia Ry!</h1>
+      <p>
+        Thank you for signing up for Illusia. We're excited to have you onboard!
+      </p>
+      <a href="http://localhost:5173/items" target="_blank">Browse our items</a>
+    </header>
+    <main>
+      <img id="signup_image" src="cid:illusia_ry_signup_notification" />
+    </main>
+  </body>
+</html>

--- a/backend/src/services/mailer.service.ts
+++ b/backend/src/services/mailer.service.ts
@@ -101,7 +101,7 @@ export class MailerService {
 
     const attachments = [{
       fileName: "welcome.jpg",
-      path: "https://crralkzqnflfzntlhccj.supabase.co/storage/v1/object/public/email-images//41103945280_6ba926b4bc_k_resized.jpg",
+      path: `${process.env.SUPABASE_URL}/storage/v1/object/public/email-images//41103945280_6ba926b4bc_k_resized.jpg`,
       cid: "illusia_ry_signup_notification"
     }]
     return this.sendEmail(to, subject, text, html, attachments);

--- a/backend/src/services/mailer.service.ts
+++ b/backend/src/services/mailer.service.ts
@@ -1,19 +1,22 @@
 import { Injectable } from '@nestjs/common';
 import { ConfigService } from '@nestjs/config';
 import { google } from 'googleapis';
-import  { createTransport, SentMessageInfo } from 'nodemailer';
+import { createTransport, SentMessageInfo } from 'nodemailer';
 // import hbs from 'nodemailer-express-handlebars';
+import { promises as fs } from 'fs';
+import * as path from 'path';
+
 
 
 @Injectable()
 export class MailerService {
-  private transporter
+  private transporter;
 
   constructor(private config: ConfigService) {
-    const clientId     = this.config.get<string>('GOOGLE_WEB_CLIENT_ID'); // Client ID from Google Cloud Console
+    const clientId = this.config.get<string>('GOOGLE_WEB_CLIENT_ID'); // Client ID from Google Cloud Console
     const clientSecret = this.config.get<string>('GOOGLE_WEB_SECRET'); // Client Secret from Google Cloud Console
     const refreshToken = this.config.get<string>('GOOGLE_WEB_REFRESH_TOKEN'); // Refresh Token from Google OAuth2 Playground
-    const userEmail    = this.config.get<string>('EMAIL'); // User email that will send the email
+    const userEmail = this.config.get<string>('EMAIL'); // User email that will send the email
 
     const oAuth2Client = new google.auth.OAuth2(
       clientId,
@@ -35,7 +38,6 @@ export class MailerService {
 
     // patch to auto-refresh the access token
     const orig = this.transporter.sendMail.bind(this.transporter);
-    
 
     this.transporter.sendMail = async (options) => {
       const { token } = await oAuth2Client.getAccessToken();
@@ -44,9 +46,17 @@ export class MailerService {
       return orig(options);
     };
   }
-  
-  
 
+  
+  /**
+   * Render HTML function that returns the page
+   * to be rendered in an email
+   */
+  async renderHtml(page: string) {
+    const htmlPath = path.join(__dirname, '..', 'email_content', `${page}.html`)
+    const htmlFromPage = await fs.readFile(htmlPath, 'utf-8');
+    return htmlFromPage
+  }
 
   /**
    * Low‐level send helper
@@ -54,13 +64,21 @@ export class MailerService {
   async sendEmail(
     to: string,
     subject: string,
-    text: string
+    text: string,
+    html?: string,
+    attachments?: {
+      fileName: string,
+      cid: string,
+      path: string
+    }[]
   ): Promise<SentMessageInfo> {
     return this.transporter.sendMail({
       from: this.config.get<string>('EMAIL'),
       to,
       subject,
       text,
+      html,
+      attachments
     });
   }
 
@@ -69,18 +87,24 @@ export class MailerService {
    * @param to           The user’s email address.
    * @param displayName  The user’s display name.
    */
-  async sendSignupEmail(
-    to: string,
-    displayName: string
-  ) {
+  async sendSignupEmail(to: string, displayName: string) {
     const subject = 'Welcome to Illusia!';
     const text = `Hi ${displayName},
 
-Thank you for signing up for Illusia. We're excited to have you onboard!
+    Thank you for signing up for Illusia. We're excited to have you onboard!
 
-Best regards,
-The Illusia Team`;
-    return this.sendEmail(to, subject, text);
+    Best regards,
+    The Illusia Team`;
+
+    const PAGE = 'signup'
+    const html = await this.renderHtml(PAGE) 
+
+    const attachments = [{
+      fileName: "welcome.jpg",
+      path: "https://crralkzqnflfzntlhccj.supabase.co/storage/v1/object/public/email-images//41103945280_6ba926b4bc_k_resized.jpg",
+      cid: "illusia_ry_signup_notification"
+    }]
+    return this.sendEmail(to, subject, text, html, attachments);
   }
 
   /**
@@ -94,7 +118,7 @@ The Illusia Team`;
     to: string,
     bookingId: string,
     startDate?: string,
-    endDate?: string
+    endDate?: string,
   ) {
     const subject = 'Your booking has been approved';
     let text = `Hello,
@@ -111,6 +135,8 @@ You can view more details in your dashboard.
 
 Thanks,
 The Illusia Team`;
-    return this.sendEmail(to, subject, text);
+    const html = `
+`;
+    return this.sendEmail(to, subject, text, html);
   }
 }


### PR DESCRIPTION
### **Summary**
- Add **renderHtml** function to mailer.service which returns the appropriate html content for the email.
- Add `src/email_content` folder in backend to store the HTML content for all emails
- Update `nest-cli.json` config to ignore the `/email_content` folder so that it's included in `/dist` and can be accessed after compilation

### **How to test it**
- Use postman to send a **signup** email. It should include an image

Let me know your thought about this feature