### PR TITLE
Ill 89 make the functionality for admin to hide items

### DIFF
--- a/backend/src/controllers/guest.controller.ts
+++ b/backend/src/controllers/guest.controller.ts
@@ -3,8 +3,10 @@ import {
   Get,
   Param,
   Query,
+  UseGuards,
 } from '@nestjs/common';
 import { GuestService } from '../services/guest.service';
+import { AuthGuard } from 'src/guards/auth.guard';
 
 
 // These routes are for users who are not logged in.
@@ -24,6 +26,12 @@ export class GuestController {
     return this.guestService.getItemsByCategories(formattedCategories);
   }
 
+  @Get('admin')
+  @UseGuards(AuthGuard('Admin',"Head Admin"))
+  async getItemsAdmin() {
+    return this.guestService.getItemsAdmin();
+  }
+
   @Get(':id')
   async getItemById(@Param('id') id: string) {
     console.log("Fetching item with ID:", id);
@@ -32,7 +40,7 @@ export class GuestController {
 
   @Get()
   async getItems() {
-    return this.guestService.getItems();
+    return this.guestService.getPublicItems();
   }
 
 }

--- a/backend/src/decorators/current-user.decorator.ts
+++ b/backend/src/decorators/current-user.decorator.ts
@@ -1,0 +1,6 @@
+import { createParamDecorator, ExecutionContext } from '@nestjs/common';
+
+export const CurrentUser = createParamDecorator(
+  (_data: unknown, ctx: ExecutionContext) =>
+    ctx.switchToHttp().getRequest().user,
+);

--- a/backend/src/guards/auth.guard.ts
+++ b/backend/src/guards/auth.guard.ts
@@ -1,0 +1,55 @@
+import {
+  Injectable,
+  CanActivate,
+  ExecutionContext,
+  UnauthorizedException,
+  ForbiddenException,
+  mixin,
+  Type,
+} from '@nestjs/common';
+import { verify } from 'jsonwebtoken';
+import type { JwtPayload } from 'jsonwebtoken';
+import { CustomRequest } from 'src/types/request.type';
+
+/** Accept one or more allowed roles */
+export function AuthGuard(...requiredRoles: string[]): Type<CanActivate> {
+  @Injectable()
+  class RoleGuard implements CanActivate {
+    async canActivate(context: ExecutionContext): Promise<boolean> {
+      const req:CustomRequest = context.switchToHttp().getRequest();
+      const auth = req.headers['authorization'];
+      if (!auth || !auth.startsWith('Bearer ')) {
+        throw new UnauthorizedException('Missing auth token');
+      }
+
+      const token = auth.slice(7);
+      let payload: JwtPayload;
+      try {
+        // Add the SUPABASE_JWT_SECRET to your environment variables
+        if (!process.env.SUPABASE_JWT_SECRET) {
+          throw new Error('JWT secret is not defined');
+        }
+        payload = verify(token, process.env.SUPABASE_JWT_SECRET!) as JwtPayload;
+      } catch(err) {
+          if (err instanceof Error) {
+              console.error('Token verification error:', err.message);
+            }
+            throw new UnauthorizedException('Invalid token');
+      }
+
+      // allow any of the required roles
+      const userRole = payload.app_metadata?.role;
+      if (!userRole || !requiredRoles.includes(userRole)) {
+        throw new ForbiddenException(
+          `Requires role: ${requiredRoles.join(' or ')}, but user has role ${userRole}`
+        );
+      }
+
+      // attach user info if you like
+        req.user = payload;
+      return true;
+    }
+  }
+
+  return mixin(RoleGuard);
+}

--- a/backend/src/services/guest.service.ts
+++ b/backend/src/services/guest.service.ts
@@ -20,9 +20,12 @@ export class GuestService {
 
   }
 
-  async getItems(): Promise<ApiResponse<Tables<'items'>[]>> {
+  async getPublicItems(): Promise<ApiResponse<Tables<'items'>[]>> {
     try {
-      const { data, error } = await this._supabase.from('items').select('*');
+      const { data, error } = await this._supabase
+      .from('items')
+      .select('*')
+      .eq("visible", true)
 
       if (error) {
         console.error('Error retrieving items: ', error);
@@ -34,7 +37,7 @@ export class GuestService {
         data: data || [],
       };
     } catch (err) {
-      console.error('Unexpected error in getItems:', err);
+      console.error('Unexpected error in getPublicItems:', err);
       throw err;
     }
   }
@@ -100,6 +103,19 @@ export class GuestService {
     }; 
     } catch (err) {
       console.error('Unexpected error in getItemById:', err);
+      throw err;
+    }
+  }
+// Fetches all items including those that are not visible
+  async getItemsAdmin(): Promise<ApiResponse<Tables<'items'>[]>> {
+    try {
+      const { data, error } = await this._supabase
+        .from('items')
+        .select('*');
+      if (error) throw error;
+      return { message: 'All items retrieved', data: data || [] };
+    } catch (err) {
+      console.error('Error in getItemsAdmin:', err);
       throw err;
     }
   }

--- a/backend/src/services/items.service.ts
+++ b/backend/src/services/items.service.ts
@@ -11,29 +11,7 @@ export class ItemService {
     private readonly supabaseService: SupabaseService
   ) {}
 
-  async getItems(req: CustomRequest): Promise<ApiResponse<Tables<'items'>[]>> {
-    const supabase = req['supabase'];
-    try {
-      const { data, error } = await supabase
-      .from('items')
-      .select('*');
-
-      if (error) {
-        console.error('Error retrieving items: ', error);
-        throw error;
-      }
-
-      return {
-        message: 'Items retrieved successfully',
-        data : data || [],
-      };
-    } catch (err) {
-      console.error('Unexpected error in getItems:', err);
-      throw err;
-    }
-  }
-
-  async addItem(req: CustomRequest, item: Tables<'items'>): Promise<ApiResponse<Tables<'items'>>> {
+  async addItem(req: CustomRequest, item: Partial<Tables<'items'>>): Promise<ApiResponse<Tables<'items'>>> {
 
 const supabase = req['supabase'];
 
@@ -44,6 +22,7 @@ const supabase = req['supabase'];
       location,
       quantity,
       category_id,
+      visible,
     } = item;
 
     try {
@@ -57,6 +36,7 @@ const supabase = req['supabase'];
           location,
           quantity,
           category_id,
+          visible: visible ?? true
           // Assuming created_at and item_id are handled by the database
         })
         .select() // Select the newly created item to return it
@@ -100,7 +80,7 @@ const supabase = req['supabase'];
   ): Promise<ApiResponse<Tables<'items'>>> {
     const supabase = req['supabase'];
 
-    const { item_name, description, image_path, location, quantity, category_id } = item;
+    const { item_name, description, image_path, location, quantity, category_id, visible } = item;
 
     const { data, error } = await supabase
       .from('items')
@@ -111,6 +91,7 @@ const supabase = req['supabase'];
         location,
         quantity,
         category_id,
+        visible,
       })
       .eq('item_id', itemId)
       .select()

--- a/backend/src/types/request.type.ts
+++ b/backend/src/types/request.type.ts
@@ -1,8 +1,9 @@
-import { SupabaseClient, User } from '@supabase/supabase-js';
+import { SupabaseClient } from '@supabase/supabase-js';
 import { Request } from 'express';
 
 export interface CustomRequest extends Request {
   messsage: string;
   supabase: SupabaseClient;
-  user: User;
+  /** Decoded JWT payload with custom app_metadata */
+  user: import('jsonwebtoken').JwtPayload & { app_metadata?: { role: string }; [key: string]: unknown };
 }

--- a/backend/src/types/supabase.ts
+++ b/backend/src/types/supabase.ts
@@ -231,6 +231,7 @@ export type Database = {
           item_name: string
           location: string
           quantity: number
+          visible: boolean
         }
         Insert: {
           category_id: string
@@ -241,6 +242,7 @@ export type Database = {
           item_name: string
           location: string
           quantity: number
+          visible?: boolean
         }
         Update: {
           category_id?: string
@@ -251,6 +253,7 @@ export type Database = {
           item_name?: string
           location?: string
           quantity?: number
+          visible?: boolean
         }
         Relationships: [
           {
@@ -579,6 +582,16 @@ export type Database = {
       custom_access_token_hook: {
         Args: { event: Json }
         Returns: Json
+      }
+      get_latest_refresh_token: {
+        Args:
+          | { p_user_id: string }
+          | { p_user_id: string }
+          | { p_user_id: string }
+        Returns: {
+          token: string
+          parent: string
+        }[]
       }
       get_user_bookings: {
         Args: { p_user_id: string }

--- a/frontend/src/api/items.ts
+++ b/frontend/src/api/items.ts
@@ -2,13 +2,18 @@ import { TablesInsert } from '../types/supabase.type';
 import { ApiResponse, Item } from '../types/types';
 import { api } from './axios';
 
-export type CreateItemPayload = Omit<TablesInsert<'items'>, 'item_id' | 'created_at' | 'user_id'> & { image_path?: string | null };
+export type CreateItemPayload = Omit<TablesInsert<'items'>, 'item_id' | 'created_at' | 'user_id'> & { image_path?: string | null, visible?: boolean };
 
 export const itemsApi = {
     getAllItems: (): Promise<ApiResponse<Item[]>> =>
         api.get('items',
             { headers: { 'Access-Control-Allow-Origin': '*' } }
         ),
+
+    getAllItemsAdmin: (): Promise<ApiResponse<Item[]>> =>
+        api.get('items/admin', {
+            headers: { 'Access-Control-Allow-Origin': '*' }
+        }),
 
     getItembyId: (id: string): Promise<ApiResponse<Item>> => {
         return api.get(`/items/${id}`)
@@ -25,4 +30,3 @@ export const itemsApi = {
         return api.delete(`/items/${id}`)
     }
 };
-

--- a/frontend/src/components/Admin/Items.tsx
+++ b/frontend/src/components/Admin/Items.tsx
@@ -10,7 +10,7 @@ function Items() {
   const { role } = useAuth();
   const items = useAppSelector(selectAllItems);
   const navigate = useNavigate()
-
+console.log('Items', items)
   // Check if user is authorized
   if (!role?.includes('Admin') || !role) return
 

--- a/frontend/src/components/Admin/Items.tsx
+++ b/frontend/src/components/Admin/Items.tsx
@@ -1,16 +1,20 @@
 import { ItemDataGrid } from '../ItemGrid/ItemDataGrid';
-import { selectAllItems } from '../../slices/itemsSlice';
-import { useAppSelector } from '../../store/hooks';
+import { fetchAllItemsAdmin, selectAllItems } from '../../slices/itemsSlice';
+import { useAppDispatch, useAppSelector } from '../../store/hooks';
 import { useAuth } from '../../hooks/useAuth';
 import { Box, Button, Link } from '@mui/material';
 import { useNavigate } from 'react-router-dom';
+import { useEffect } from 'react';
 
 
 function Items() {
   const { role } = useAuth();
   const items = useAppSelector(selectAllItems);
   const navigate = useNavigate()
-console.log('Items', items)
+  const dispatch = useAppDispatch();
+  useEffect(() => {
+    dispatch(fetchAllItemsAdmin());
+  }, [dispatch]);
   // Check if user is authorized
   if (!role?.includes('Admin') || !role) return
 

--- a/frontend/src/components/ItemGrid/ItemDataGrid.tsx
+++ b/frontend/src/components/ItemGrid/ItemDataGrid.tsx
@@ -1,23 +1,25 @@
 import { DataGrid, GridColDef } from '@mui/x-data-grid';
-import { Box, IconButton, Typography } from '@mui/material';
+import { Box, IconButton, Typography, Select, MenuItem } from '@mui/material';
 import { renderCellExpand } from './RenderCellExpand';
 import { Item } from '../../types/types';
-import { useAppDispatch } from '../../store/hooks';
+import { useAppDispatch, useAppSelector } from '../../store/hooks';
 import { deleteItem, fetchAllItems } from '../../slices/itemsSlice';
+import { updateItemVisibility } from '../../slices/itemsSlice';
 import { formatDate } from '../../utility/formatDate';
 import SearchIcon from '@mui/icons-material/Search';
 import DeleteIcon from '@mui/icons-material/Delete';
 import { useNavigate } from 'react-router-dom';
+import { selectAllCategories } from '../../slices/itemsSlice';
+import { getCategoryName } from '../../utility/getCategoryName';
 
 interface ItemDataGridProps {
   data: Item[];
 }
-
-const uuidLength = 230;
 const timeStampLength = 150;
 
 export const ItemDataGrid: React.FC<ItemDataGridProps> = ({ data }) => {
   const dispatch = useAppDispatch();
+  const categories = useAppSelector(selectAllCategories);
   const handleDelete = (id: string) => {
     if (confirm('Are you sure you want to delete this item?')) {
       dispatch(deleteItem(id)).then(() => dispatch(fetchAllItems()));
@@ -28,20 +30,23 @@ export const ItemDataGrid: React.FC<ItemDataGridProps> = ({ data }) => {
 
   const columns: GridColDef[] = [
     {
+      field: 'item_id',
+      headerClassName: 'super-app-theme--header',
+      headerAlign: 'left',
+      headerName: 'ID',
+      width: 100,
+      renderCell: (params) => (
+        
+        String(params.value).slice(0, 8)
+      ),
+    },
+    {
       field: 'item_name',
       headerClassName: 'super-app-theme--header',
       headerAlign: 'left',
       headerName: 'Name',
       minWidth: 150,
       renderCell: renderCellExpand,
-    },
-    {
-      field: 'item_id',// ID of the item
-      headerClassName: 'super-app-theme--header',// Class to edit the Header CSS
-      headerAlign: 'left',
-      headerName: 'ID',
-      width: uuidLength, // Adjust width as needed
-      renderCell: renderCellExpand,// Function to render the cell content with word wrapping
     },
     {
       field: 'description',
@@ -53,12 +58,29 @@ export const ItemDataGrid: React.FC<ItemDataGridProps> = ({ data }) => {
       renderCell: renderCellExpand,
     },
     {
-      field: 'image_path',
+      field: 'visible',
       headerClassName: 'super-app-theme--header',
-      headerName: 'Image Path',
+      headerName: 'Visibility',
       headerAlign: 'left',
-      minWidth: 240,
-      renderCell: renderCellExpand,
+      width: 120,
+      renderCell: (params) => (
+        <Select
+          value={params.row.visible ? 'Visible' : 'Hidden'}
+          size="small"
+          onChange={(e) => {
+            const newVisible = e.target.value === 'Visible';
+            if (newVisible !== params.row.visible) {
+              dispatch(
+                updateItemVisibility({ id: params.row.item_id, visible: newVisible })
+              );
+            }
+          }}
+          sx={{ fontSize: '0.85rem' }}
+        >
+          <MenuItem value="Visible">Visible</MenuItem>
+          <MenuItem value="Hidden">Hidden</MenuItem>
+        </Select>
+      ),
     },
     {
       field: 'location',
@@ -71,7 +93,7 @@ export const ItemDataGrid: React.FC<ItemDataGridProps> = ({ data }) => {
     {
       field: 'quantity',
       headerClassName: 'super-app-theme--header',
-      headerName: 'Pcs',
+      headerName: 'Qty',
       headerAlign: 'left',
       type: 'number',
       width: 50,
@@ -82,8 +104,10 @@ export const ItemDataGrid: React.FC<ItemDataGridProps> = ({ data }) => {
       headerClassName: 'super-app-theme--header',
       headerName: 'Category',
       headerAlign: 'left',
-      minWidth: uuidLength,
-      renderCell: renderCellExpand,
+      minWidth: 150,
+      renderCell: (params) => (
+        getCategoryName(categories, params.value)
+        ),
     },
     {
       field: 'created_at',

--- a/frontend/src/components/Items.tsx
+++ b/frontend/src/components/Items.tsx
@@ -3,6 +3,7 @@ import { useAppDispatch, useAppSelector } from '../store/hooks';
 import {
   selectAllCategories,
   selectAllItems,
+  selectVisibleItems,
 } from '../slices/itemsSlice';
 import {
   Button,
@@ -47,7 +48,7 @@ import { Item } from '../types/types';
 import { showCustomSnackbar } from './CustomSnackbar';
 
 function Items() {
-  const items = useAppSelector(selectAllItems);
+  const items = useAppSelector(selectVisibleItems);
   const categories = useAppSelector(selectAllCategories);
   const dispatch = useAppDispatch();
   const [offset, setOffset] = useState(0);

--- a/frontend/src/components/Items.tsx
+++ b/frontend/src/components/Items.tsx
@@ -2,7 +2,6 @@ import { useEffect, useState } from 'react';
 import { useAppDispatch, useAppSelector } from '../store/hooks';
 import {
   selectAllCategories,
-  selectAllItems,
   selectVisibleItems,
 } from '../slices/itemsSlice';
 import {

--- a/frontend/src/pages/Home.tsx
+++ b/frontend/src/pages/Home.tsx
@@ -5,7 +5,6 @@ import { fetchAllCategories, selectAllCategories } from '../slices/itemsSlice';
 import { Link } from 'react-router-dom';
 import { GridExpandMoreIcon } from '@mui/x-data-grid';
 import ArrowForwardIosRoundedIcon from '@mui/icons-material/ArrowForwardIosRounded';
-import { getAccessToken } from '../utility/getToken';
 
 
 function Home() {
@@ -28,7 +27,6 @@ function Home() {
 
   return (
     <Box id='home'>
-      <Button onClick={getAccessToken} variant='contained'>Get Access Token</Button>
       {/* Hero banner */}
       <Box component='section' id='hero-container'
         sx={{

--- a/frontend/src/pages/Home.tsx
+++ b/frontend/src/pages/Home.tsx
@@ -5,6 +5,7 @@ import { fetchAllCategories, selectAllCategories } from '../slices/itemsSlice';
 import { Link } from 'react-router-dom';
 import { GridExpandMoreIcon } from '@mui/x-data-grid';
 import ArrowForwardIosRoundedIcon from '@mui/icons-material/ArrowForwardIosRounded';
+import { getAccessToken } from '../utility/getToken';
 
 
 function Home() {
@@ -27,6 +28,7 @@ function Home() {
 
   return (
     <Box id='home'>
+      <Button onClick={getAccessToken} variant='contained'>Get Access Token</Button>
       {/* Hero banner */}
       <Box component='section' id='hero-container'
         sx={{

--- a/frontend/src/types/supabase.type.ts
+++ b/frontend/src/types/supabase.type.ts
@@ -58,7 +58,21 @@ export type Database = {
             foreignKeyName: "bookings_user_id_fkey"
             columns: ["user_id"]
             isOneToOne: false
+            referencedRelation: "user_activity_view_test"
+            referencedColumns: ["user_id"]
+          },
+          {
+            foreignKeyName: "bookings_user_id_fkey"
+            columns: ["user_id"]
+            isOneToOne: false
             referencedRelation: "user_role_view"
+            referencedColumns: ["user_id"]
+          },
+          {
+            foreignKeyName: "bookings_user_id_fkey"
+            columns: ["user_id"]
+            isOneToOne: false
+            referencedRelation: "user_with_roles_view"
             referencedColumns: ["user_id"]
           },
           {
@@ -217,6 +231,7 @@ export type Database = {
           item_name: string
           location: string
           quantity: number
+          visible: boolean
         }
         Insert: {
           category_id: string
@@ -227,6 +242,7 @@ export type Database = {
           item_name: string
           location: string
           quantity: number
+          visible?: boolean
         }
         Update: {
           category_id?: string
@@ -237,6 +253,7 @@ export type Database = {
           item_name?: string
           location?: string
           quantity?: number
+          visible?: boolean
         }
         Relationships: [
           {
@@ -396,7 +413,21 @@ export type Database = {
             foreignKeyName: "user_roles_user_id_fkey"
             columns: ["user_id"]
             isOneToOne: false
+            referencedRelation: "user_activity_view_test"
+            referencedColumns: ["user_id"]
+          },
+          {
+            foreignKeyName: "user_roles_user_id_fkey"
+            columns: ["user_id"]
+            isOneToOne: false
             referencedRelation: "user_role_view"
+            referencedColumns: ["user_id"]
+          },
+          {
+            foreignKeyName: "user_roles_user_id_fkey"
+            columns: ["user_id"]
+            isOneToOne: false
+            referencedRelation: "user_with_roles_view"
             referencedColumns: ["user_id"]
           },
           {
@@ -445,7 +476,21 @@ export type Database = {
             foreignKeyName: "bookings_user_id_fkey"
             columns: ["user_id"]
             isOneToOne: false
+            referencedRelation: "user_activity_view_test"
+            referencedColumns: ["user_id"]
+          },
+          {
+            foreignKeyName: "bookings_user_id_fkey"
+            columns: ["user_id"]
+            isOneToOne: false
             referencedRelation: "user_role_view"
+            referencedColumns: ["user_id"]
+          },
+          {
+            foreignKeyName: "bookings_user_id_fkey"
+            columns: ["user_id"]
+            isOneToOne: false
+            referencedRelation: "user_with_roles_view"
             referencedColumns: ["user_id"]
           },
           {
@@ -479,12 +524,40 @@ export type Database = {
         }
         Relationships: []
       }
+      user_activity_view: {
+        Row: {
+          confirmed_at: string | null
+          display_name: string | null
+          last_sign_in_at: string | null
+        }
+        Relationships: []
+      }
+      user_activity_view_test: {
+        Row: {
+          confirmed_at: string | null
+          display_name: string | null
+          email: string | null
+          last_sign_in_at: string | null
+          user_id: string | null
+        }
+        Relationships: []
+      }
       user_role_view: {
         Row: {
           display_name: string | null
           email: string | null
           role_title: string | null
           user_id: string | null
+        }
+        Relationships: []
+      }
+      user_with_roles_view: {
+        Row: {
+          display_name: string | null
+          email: string | null
+          role_title: string | null
+          user_id: string | null
+          user_status: string | null
         }
         Relationships: []
       }
@@ -510,6 +583,16 @@ export type Database = {
         Args: { event: Json }
         Returns: Json
       }
+      get_latest_refresh_token: {
+        Args:
+          | { p_user_id: string }
+          | { p_user_id: string }
+          | { p_user_id: string }
+        Returns: {
+          token: string
+          parent: string
+        }[]
+      }
       get_user_bookings: {
         Args: { p_user_id: string }
         Returns: {
@@ -533,6 +616,14 @@ export type Database = {
         Returns: boolean
       }
       is_user_admin: {
+        Args: { p_user_id: string }
+        Returns: boolean
+      }
+      is_user_head_admin: {
+        Args: { p_user_id: string }
+        Returns: boolean
+      }
+      is_user_strict_admin: {
         Args: { p_user_id: string }
         Returns: boolean
       }

--- a/frontend/src/types/types.ts
+++ b/frontend/src/types/types.ts
@@ -9,6 +9,7 @@ export interface Item {
   location: string;
   quantity: number;
   created_at: string;
+  visible?: boolean;
 }
 
 export interface ItemState {
@@ -34,6 +35,7 @@ export interface FormData {
   category_id: string; // Assuming this holds the ID, maybe from a select input
   location: string;
   quantity: number;
+  visible?: boolean;
   // Add other relevant fields from your 'items' table if needed
 }
 

--- a/frontend/src/utility/getCategoryName.ts
+++ b/frontend/src/utility/getCategoryName.ts
@@ -1,0 +1,18 @@
+import { Tables } from "../types/supabase.type";
+
+/**
+ * Simple helper to map a category_id to its human‑readable name.
+ *
+ * @param categories An array of categories (usually from Redux state)
+ * @param category_id The id you want to resolve
+ * @returns The category’s name, or `"Unknown"` if not found.
+ */
+export function getCategoryName(
+    categories: Array<Pick<Tables<'categories'>, 'category_id' | 'category_name'>>,
+    category_id: string | null | undefined,
+  ): string {
+  if (!category_id) return 'Unknown';
+
+  const match = categories.find((c) => c.category_id === category_id);
+  return match && match.category_name ? match.category_name : 'Unknown';
+}


### PR DESCRIPTION
This pull request introduces authentication and authorization features, enhances role-based access control, and adds visibility management for items. It also includes updates to both backend and frontend components to support these features.

### Backend Changes

#### Authentication & Authorization:
* Added an `AuthGuard` in `src/guards/auth.guard.ts` to enforce role-based access control using Supabase JWT tokens. The guard verifies the token, checks user roles, and attaches the decoded payload to the request.
* Introduced a `@CurrentUser()` decorator in `src/decorators/current-user.decorator.ts` to simplify accessing the authenticated user's payload in controllers.
* Updated `GuestController` to include an admin-only endpoint (`getItemsAdmin`) protected by `AuthGuard`. [[1]](diffhunk://#diff-5741d4890144ecf35712eb8194bd3ff478d4a6cef307da8f2ec7cbdda29ef94eR29-R34) [[2]](diffhunk://#diff-5741d4890144ecf35712eb8194bd3ff478d4a6cef307da8f2ec7cbdda29ef94eL35-R43)

#### Item Visibility Management:
* Added a `visible` field to the `items` table schema in `backend/src/types/supabase.ts` to track item visibility. [[1]](diffhunk://#diff-028dfa7efb881da1e0f897da3f82d162782019889d1c01a29877aae1947f34f4R234) [[2]](diffhunk://#diff-028dfa7efb881da1e0f897da3f82d162782019889d1c01a29877aae1947f34f4R245) [[3]](diffhunk://#diff-028dfa7efb881da1e0f897da3f82d162782019889d1c01a29877aae1947f34f4R256)
* Updated `GuestService` to fetch only visible items for public endpoints (`getPublicItems`) and all items for admin endpoints (`getItemsAdmin`). [[1]](diffhunk://#diff-7b1159341ee982bbc509cdc6793f8601aaf132d051cf278b66785c2d36f3ded5L23-R28) [[2]](diffhunk://#diff-7b1159341ee982bbc509cdc6793f8601aaf132d051cf278b66785c2d36f3ded5R109-R121)
* Modified the `ItemService` to include the `visible` field when adding or updating items. [[1]](diffhunk://#diff-397eda9c17c255f0146c6ea5d79ee811d83144d5ffe745e3e08557bc5a3eab64R25) [[2]](diffhunk://#diff-397eda9c17c255f0146c6ea5d79ee811d83144d5ffe745e3e08557bc5a3eab64R39) [[3]](diffhunk://#diff-397eda9c17c255f0146c6ea5d79ee811d83144d5ffe745e3e08557bc5a3eab64L103-R83) [[4]](diffhunk://#diff-397eda9c17c255f0146c6ea5d79ee811d83144d5ffe745e3e08557bc5a3eab64R94)

#### Type Updates:
* Enhanced the `CustomRequest` type to include the decoded JWT payload with role information.

### Frontend Changes

#### Admin Features:
* Added an admin-specific API call (`getAllItemsAdmin`) in `frontend/src/api/items.ts` to fetch all items, including hidden ones. [[1]](diffhunk://#diff-a690019b8ae86804e09b948a4fe3a283005df066a375b6b2d411b77e4ec6c07aL5-R17) [[2]](diffhunk://#diff-a690019b8ae86804e09b948a4fe3a283005df066a375b6b2d411b77e4ec6c07aL28)
* Updated the `Admin/Items` component to fetch admin items on load using the new API.

#### Item Visibility Management:
* Enhanced the `ItemDataGrid` component to include a dropdown for toggling item visibility directly from the admin interface. This updates the `visible` field in real time. [[1]](diffhunk://#diff-a370495f8c66869bdc0a6970d1264f18f4e5f560fb5addf24027b085e1035961L2-R22) [[2]](diffhunk://#diff-a370495f8c66869bdc0a6970d1264f18f4e5f560fb5addf24027b085e1035961L56-R83)

These changes collectively improve the application's security, enable role-based access control, and provide better item management capabilities for administrators.

## Tested
- I tested all new endpoints with Postman and then our frontend.
- I tested the visibility of items with the Manage and View Items tabs of `/items`. It worked well and the items were displayed correctly to the admin and user. I had to add another fetch in the /items page so the admin view would not be in sync with the users view.
- Checked that the overall app is not broken. And I mostly changed the `/items` page.
