### PR TITLE
Modifying cart in general

### DIFF
--- a/frontend/src/selectors/availabilitySelector.ts
+++ b/frontend/src/selectors/availabilitySelector.ts
@@ -9,6 +9,7 @@ export const checkAvailabilityForItemOnDates = (
     quantity: number,
     start_date: string,
     end_date: string,
+    includeCart: boolean = true
 ) =>
     createSelector(
         [
@@ -18,17 +19,17 @@ export const checkAvailabilityForItemOnDates = (
                 start_date,
                 end_date,
             ),
-            selectQtyForItemInCartByIdInDateRange(item_id, start_date, end_date),
+            selectQtyForItemInCartByIdInDateRange(item_id),
         ],
         (item, itemQtyInReservatios, itemQtyInCart): Result => {
 
             const overallItemQty = (item?.quantity ? item.quantity : 0);
-            const availableQuantityOfItem = overallItemQty - itemQtyInCart - itemQtyInReservatios;
+            const availableQuantityOfItem = overallItemQty - itemQtyInReservatios - (includeCart ? itemQtyInCart : 0);
 
-            if (overallItemQty === itemQtyInCart)
+            if ((includeCart) && (overallItemQty === itemQtyInCart))
                 return { severity: 'warning', message: 'Max quantity of the item is already in cart' };
 
-            if (availableQuantityOfItem === 0) {
+            if (includeCart && availableQuantityOfItem === 0) {
                 if (itemQtyInCart === 0) return { severity: 'warning', message: "Item is not available for selected dates" };
                 else return { severity: 'warning', message: "Max quantity of the item for the dates is already in cart" };
 
@@ -41,7 +42,7 @@ export const checkAvailabilityForItemOnDates = (
                 ? { severity: 'success', data: true }
                 : {
                     severity: 'warning',
-                    message: `Not enough of item available for selected dates. Only available ${availableQuantityOfItem}`,
+                    message: `Not enough of item available for selected dates. Only available ${overallItemQty - itemQtyInReservatios}`,
                 };
         },
 

--- a/frontend/src/slices/cartSlice.ts
+++ b/frontend/src/slices/cartSlice.ts
@@ -11,6 +11,11 @@ export const cartSlice = createSlice({
     name: 'cart',
     initialState,
     reducers: {
+        setDateRange: (state, action) => {
+            state.selectedDateRange.start_date = action.payload.newStartDate;
+            state.selectedDateRange.end_date = action.payload.newEndDate;
+            localStorage.setItem('savedCart', JSON.stringify(state));
+        },
         addItemToCart: (state, action) => {
             // Destructure new item
             const { item, quantity, start_date, end_date } = action.payload;
@@ -20,7 +25,7 @@ export const cartSlice = createSlice({
             if (itemAlreadyInCart !== -1) {
                 state.cart[itemAlreadyInCart].quantity += quantity;
             } else {
-                const newItem = {...item, ['quantity']: quantity}
+                const newItem = { ...item, ['quantity']: quantity }
                 state.cart.push(newItem);
             }
             state.selectedDateRange = { start_date, end_date };
@@ -72,6 +77,7 @@ export const {
     removeItemFromCart,
     emptyCart,
     loadCartFromStorage,
+    setDateRange
 } = cartSlice.actions;
 
 export const selectItemInCartById = (id: string) => (state: RootState) => {
@@ -99,36 +105,17 @@ export const selectQtyForItemInCartByIdInDateRange =
         }
     };
 
+/*
 export const setDateRange = (newStartDate: string | null, newEndDate: string | null) => (state: RootState) => {
-    state.cart.selectedDateRange.start_date = newStartDate;
-    state.cart.selectedDateRange.end_date = newEndDate;
+state.cart.selectedDateRange.start_date = newStartDate;
+state.cart.selectedDateRange.end_date = newEndDate;
 
-}
-
-
+}*/
 
 export const selectDateRange = (state: RootState) => {
+    console.log(state.cart.selectedDateRange);
+
     return state.cart.selectedDateRange;
 }
-/*
-export const selectQtyForItemInCartByIdInDateRange2 = (id: string, start_date: string, end_date: string) => (state: RootState) => {
-    const itemInCartReservations: LocalReservation[] = state.cart.cart.filter((item) => item.item_id === id);
-
-    if (itemInCartReservations.length > 0) {
-        // if any of the instances of the items found in cart
-
-        if ((itemInCartReservations[0].start_date === start_date) || (itemInCartReservations[0].end_date === end_date)) {
-            // item added for already existing time range
-            return itemInCartReservations[0].quantity;
-        } else {
-            // item added fora new time range
-            return -1;
-        }
-        // console.log(getOverlappingRange(parseDate(itemInCartReservations[0].start_date), parseDate(itemInCartReservations[0].end_date), parseDate(start_date), parseDate(end_date)));
-    } else {
-        // new item added to cart
-        return 0;
-    }
-}*/
 
 export default cartSlice.reducer;

--- a/frontend/src/slices/cartSlice.ts
+++ b/frontend/src/slices/cartSlice.ts
@@ -15,6 +15,13 @@ export const cartSlice = createSlice({
             state.selectedDateRange.start_date = action.payload.newStartDate;
             state.selectedDateRange.end_date = action.payload.newEndDate;
             localStorage.setItem('savedCart', JSON.stringify(state));
+            // mb not needed
+        },
+        setCartItems: (state, action) => {
+            state.cart = action.payload.cart;
+            state.selectedDateRange.start_date = action.payload.newStartDate;
+            state.selectedDateRange.end_date = action.payload.newEndDate;
+            localStorage.setItem('savedCart', JSON.stringify(state));
         },
         addItemToCart: (state, action) => {
             // Destructure new item
@@ -77,7 +84,8 @@ export const {
     removeItemFromCart,
     emptyCart,
     loadCartFromStorage,
-    setDateRange
+    setDateRange,
+    setCartItems
 } = cartSlice.actions;
 
 export const selectItemInCartById = (id: string) => (state: RootState) => {
@@ -85,36 +93,20 @@ export const selectItemInCartById = (id: string) => (state: RootState) => {
 };
 
 export const selectQtyForItemInCartByIdInDateRange =
-    (id: string, start_date: string, end_date: string) => (state: RootState) => {
+    (id: string) => (state: RootState) => {
         const itemInCartReservations = state.cart.cart.filter(
             (item) => item.item_id === id,
         );
 
         if (itemInCartReservations.length > 0) {
+            return itemInCartReservations[0].quantity;
             // if any of the instances of the items found in cart
-            if (
-                state.cart.selectedDateRange.start_date === start_date ||
-                state.cart.selectedDateRange.end_date === end_date
-            ) {
-                return itemInCartReservations[0].quantity; // item added for already existing time range
-            } else {
-                return -1; // item added for a new time range
-            }
         } else {
             return 0; // new item added to cart
         }
     };
 
-/*
-export const setDateRange = (newStartDate: string | null, newEndDate: string | null) => (state: RootState) => {
-state.cart.selectedDateRange.start_date = newStartDate;
-state.cart.selectedDateRange.end_date = newEndDate;
-
-}*/
-
 export const selectDateRange = (state: RootState) => {
-    console.log(state.cart.selectedDateRange);
-
     return state.cart.selectedDateRange;
 }
 


### PR DESCRIPTION
So now it is possible to fully modify the cart. The cart has two states - local cart and redux cart. They are updated at the same time, but when the edit cart is enabled, then only local cart is modified. Local cart is what shown in the cart page, this way it is much less code.

This way, if the page is refreshed or cancel is pressed, the data is restored from the redux cart.

If changes are accepted - then the local cart is copied into redux. 

Everything inside the cart is modifiable ( dates, quantities). 

Also all the errors are shown right on the page, and it is impossible to make a booking while editing is in the process. also impossible to change the date if there is an error.

Ui is probably not the best, sorry for that.

Basically, the same scheme with a couple of tweaks could be used, if we go with the modification of the older bookings.