### PR TITLE
Ill 196 ux add UI for no items

### DIFF
--- a/frontend/src/components/Items.tsx
+++ b/frontend/src/components/Items.tsx
@@ -2,6 +2,7 @@ import { useEffect, useState } from 'react';
 import { useAppDispatch, useAppSelector } from '../store/hooks';
 import {
   selectAllCategories,
+  selectItemsLoading,
   selectVisibleItems,
 } from '../slices/itemsSlice';
 import {
@@ -45,9 +46,11 @@ import {
 } from '@internationalized/date';
 import { Item } from '../types/types';
 import { showCustomSnackbar } from './CustomSnackbar';
+import Spinner from './Spinner';
 
 function Items() {
   const items = useAppSelector(selectVisibleItems);
+  const itemsLoading = useAppSelector(selectItemsLoading);
   const categories = useAppSelector(selectAllCategories);
   const dispatch = useAppDispatch();
   const [offset, setOffset] = useState(0);
@@ -75,7 +78,6 @@ function Items() {
       });
     }
   }, []);
-
 
 
   const addToCart = (item: Item, quantity: number = 1) => {
@@ -290,82 +292,96 @@ function Items() {
           },
         }}
       >
-        <Stack
-          direction={'row'}
-          flexWrap={'wrap'}
-          gap={3}
-          justifySelf={'center'}
-          padding={'none'}
-          textAlign={'start'}
-        >
-          {filteredItems.slice(offset, offset + 8).map((item) => (
-            <Card
-              component={Link}
-              to={`/items/${item.item_id}`}
-              key={item.item_id}
-              sx={{
-                width: 280,
-                minHeight: 300,
-                boxShadow: 'none',
-                textDecoration: 'none',
-                flex: 1,
-                flexBasis: 230,
-                maxWidth: 300
-              }}
-            >
-              <Box sx={{
-                height: 300,
-                borderRadius: '14px',
-                bgcolor: 'background.lightgrey',
-                overflow: 'hidden',
-                '&:hover img': { scale: 1.03 }
-              }}>
-                <CardMedia
-                  component="img"
-                  image={item.image_path || '/src/assets/broken_img.png'}
-                  onError={handleBrokenImg}
-                  sx={{
-                    height: '100%',
-                    transition: 'scale 200ms'
-                  }}
-                />
-              </Box>
-              <CardContent
-                sx={{
-                  padding: '0.5rem 0',
-                  mb: '1rem',
-                  display: 'flex',
-                  justifyContent: 'space-between',
-                }}
-              >
-                <Box
-                  sx={{ width: '80%', alignItems: 'center', display: 'flex' }}
-                >
-                  <Typography variant="body1" sx={{ width: '70%' }}>
-                    {item.item_name}
-                  </Typography>
-                </Box>
 
-                <CardActions
-                  sx={{ padding: 0, justifySelf: 'end', width: 'fit-content' }}
+        {itemsLoading ? <Spinner />
+          :
+          <>
+            {filteredItems.length > 0 ?
+              <>
+                <Stack
+                  direction={'row'}
+                  flexWrap={'wrap'}
+                  gap={3}
+                  justifySelf={'center'}
+                  padding={'none'}
+                  textAlign={'start'}
                 >
-                  <Button
-                    sx={{ padding: '3px', minWidth: 'fit-content' }}
-                    onClick={(e) => {
-                      // Stop add-to-cart btn from navigating elsewhere
-                      e.preventDefault();
-                      e.stopPropagation();
-                      addToCart(item);
-                    }}
-                  >
-                    <AddCircleOutlineOutlinedIcon />
-                  </Button>
-                </CardActions>
-              </CardContent>
-            </Card>
-          ))}
-        </Stack>
-        <Pagination items={filteredItems} setOffset={setOffset} />
+                  {filteredItems.slice(offset, offset + 8).map((item) => (
+                    <Card
+                      component={Link}
+                      to={`/items/${item.item_id}`}
+                      key={item.item_id}
+                      sx={{
+                        width: 280,
+                        minHeight: 300,
+                        boxShadow: 'none',
+                        textDecoration: 'none',
+                        flex: 1,
+                        flexBasis: 230,
+                        maxWidth: 300
+                      }}
+                    >
+                      <Box sx={{
+                        height: 300,
+                        borderRadius: '14px',
+                        bgcolor: 'background.lightgrey',
+                        overflow: 'hidden',
+                        '&:hover img': { scale: 1.03 }
+                      }}>
+                        <CardMedia
+                          component="img"
+                          image={item.image_path || '/src/assets/broken_img.png'}
+                          onError={handleBrokenImg}
+                          sx={{
+                            height: '100%',
+                            transition: 'scale 200ms'
+                          }}
+                        />
+                      </Box>
+                      <CardContent
+                        sx={{
+                          padding: '0.5rem 0',
+                          mb: '1rem',
+                          display: 'flex',
+                          justifyContent: 'space-between',
+                        }}
+                      >
+                        <Box
+                          sx={{ width: '80%', alignItems: 'center', display: 'flex' }}
+                        >
+                          <Typography variant="body1" sx={{ width: '70%' }}>
+                            {item.item_name}
+                          </Typography>
+                        </Box>
+
+                        <CardActions
+                          sx={{ padding: 0, justifySelf: 'end', width: 'fit-content' }}
+                        >
+                          <Button
+                            sx={{ padding: '3px', minWidth: 'fit-content' }}
+                            onClick={(e) => {
+                              // Stop add-to-cart btn from navigating elsewhere
+                              e.preventDefault();
+                              e.stopPropagation();
+                              addToCart(item);
+                            }}
+                          >
+                            <AddCircleOutlineOutlinedIcon />
+                          </Button>
+                        </CardActions>
+                      </CardContent>
+                    </Card>
+                  ))}
+                </Stack>
+                <Pagination items={filteredItems} setOffset={setOffset} />
+              </> :
+              <Box sx={{ height: 300, justifyContent: 'center', display: 'flex', flexDirection: 'column', alignItems: 'center' }}>
+                <Typography variant='heading_secondary_bold' fontSize={24}>No items found!</Typography>
+                <Typography>Try updating categories to explore our collection</Typography>
+              </Box>
+            }
+          </>
+        }
       </Box>
     </Box>
   );

--- a/frontend/src/components/Items.tsx
+++ b/frontend/src/components/Items.tsx
@@ -293,7 +293,10 @@ function Items() {
         }}
       >
 
-        {itemsLoading ? <Spinner />
+        {itemsLoading ?
+          <Box sx={{ margin: '0 auto' }}>
+            <Spinner />
+          </Box>
           :
           <>
             {filteredItems.length > 0 ?

--- a/frontend/src/components/Spinner.tsx
+++ b/frontend/src/components/Spinner.tsx
@@ -1,4 +1,5 @@
 import { Box } from '@mui/material';
+import './pyramid-loader.css'
 
 function Spinner() {
   return (

--- a/frontend/src/slices/itemsSlice.ts
+++ b/frontend/src/slices/itemsSlice.ts
@@ -87,8 +87,8 @@ export const itemsSlice = createSlice({
       state.loading = true
     })
     builder.addCase(fetchAllItems.fulfilled, (state, action) => {
-      state.loading = false
       state.items = action.payload.data;
+      //state.loading = false
     })
     builder.addCase(fetchAllItems.rejected, (state) => {
       state.loading = false
@@ -98,12 +98,12 @@ export const itemsSlice = createSlice({
       state.loading = true;
     });
     builder.addCase(fetchAllItemsAdmin.fulfilled, (state, action) => {
-      state.loading = false;
       state.items = action.payload.data;
+      state.loading = false;
     });
     builder.addCase(fetchAllItemsAdmin.rejected, (state) => {
-      state.loading = false;
       state.error = 'Could not fetch admin items';
+      state.loading = false;
     });
     builder.addCase(fetchAllCategories.pending, (state) => {
       state.loading = true
@@ -113,8 +113,8 @@ export const itemsSlice = createSlice({
       state.categories = action.payload.data
     })
     builder.addCase(fetchAllCategories.rejected, (state) => {
-      state.loading = false
       state.error = 'Could not fetch items'
+      state.loading = false
     })
     builder.addCase(fetchItemById.pending, (state) => {
       state.loading = true
@@ -129,7 +129,6 @@ export const itemsSlice = createSlice({
       }
     })
     builder.addCase(createItem.fulfilled, (state, action) => {
-
       state.items.push(action.payload.data);
     })
     builder.addCase(deleteItem.fulfilled, (state, action) => {
@@ -171,6 +170,8 @@ export const selectVisibleItems = createSelector(
   selectAllItems,
   (items) => items.filter((i) => i.visible),
 );
+
+export const selectItemsLoading = (state: RootState) => state.items.loading
 
 export const selectItemById = (id: string) => (state: RootState) => {
   return state.items.items.find((item) => item.item_id === id);


### PR DESCRIPTION
### **Summary**
- Added UI for 'No items found'
- Added `Spinner` when items are loading (Enable throttling if you will be testing this)
- Exported loading state from `itemsSlice`
- 🐛 BUG FIX: Fix spinner by importing spinner CSS
- 🐛  BUG FIX: No longer shows pagination arrows when there are no items

### Loading state
![Skärmbild 2025-05-08 084813](https://github.com/user-attachments/assets/20cff3f8-4171-4569-9f0e-f49a4eb7e8d5)

### No items state
![Skärmbild 2025-05-08 084841](https://github.com/user-attachments/assets/1aad4d9f-4695-4702-835b-8ee257db45d5)
