### PR TITLE
Ill 169 user can cancel pending bookings

### DIFF
--- a/frontend/src/api/bookings.ts
+++ b/frontend/src/api/bookings.ts
@@ -12,10 +12,8 @@ export const bookingsApi = {
         return api.get(`/bookings/${id}`)
     },
 
-    createBooking: async (newBooking: object) => {
-
-        const response = await api.post('bookings/rpc', newBooking)
-        return response;
+    createBooking: async (newBooking: object): Promise<{ booking_id: string; status: string }> => {
+        return api.post('bookings/rpc', newBooking)
     },
 
     /**
@@ -23,11 +21,11 @@ export const bookingsApi = {
    */
   getUserBookings: (
     userId: string,
-  ): Promise<ApiResponse<BookingWithItems>> =>
+  ): Promise<ApiResponse<Booking[]>> =>
     api.get(`bookings/user/${userId}`, {
       headers: { 'Access-Control-Allow-Origin': '*' },
     }),
-    updateBookingStatus: (id: string, status: "approved" | "rejected"): Promise<ApiResponse<Booking>> => {
+    updateBookingStatus: (id: string, status: "approved" | "rejected" | "cancelled"): Promise<ApiResponse<Booking>> => {
         return api.patch(`/bookings/${id}`, { status })
     },
     removeBooking: (id: string): Promise<ApiResponse<Booking>> => {

--- a/frontend/src/components/Admin/ItemView.tsx
+++ b/frontend/src/components/Admin/ItemView.tsx
@@ -121,7 +121,7 @@ const SingleItem = () => {
           <CardMedia
             component="img"
             onError={handleBrokenImg}
-            image={item?.image_path
+            image={item?.image_path ?? '/src/assets/broken_img.png'
             }
             alt={item?.item_name}
             sx={{

--- a/frontend/src/components/Booking.tsx
+++ b/frontend/src/components/Booking.tsx
@@ -1,14 +1,57 @@
-import { Box, Stack, Table, TableBody, TableCell, TableContainer, TableHead, TableRow, Typography } from '@mui/material';
-import { useEffect } from 'react';
+import {
+  Box,
+  Button,
+  Dialog,
+  DialogActions,
+  DialogTitle,
+  Link,
+  Stack,
+  Table,
+  TableBody,
+  TableCell,
+  TableContainer,
+  TableHead,
+  TableRow,
+  Typography,
+} from '@mui/material';
+import { useEffect, useState } from 'react';
 import { useNavigate, useParams } from 'react-router-dom';
 import { useAppDispatch, useAppSelector } from '../store/hooks';
-import { fetchBooking, selectBooking } from '../slices/bookingsSlice';
+import {
+  deleteBooking,
+  fetchBooking,
+  selectBooking,
+  selectBookingsLoading,
+  updateBookingStatus,
+} from '../slices/bookingsSlice';
+import Spinner from './Spinner';
+import { showCustomSnackbar } from './CustomSnackbar';
 
 function SingleBooking() {
   const navigate = useNavigate();
   const dispatch = useAppDispatch();
   const { booking_id } = useParams();
   const booking_selector = useAppSelector(selectBooking);
+  const loading = useAppSelector(selectBookingsLoading);
+  const [wantsToCancel, setWantsToCancel] = useState(false)
+
+  /* ─────────────────── handlers ─────────────────── */
+  const handleCancel = (booking_id: string) => {
+    if (booking.status === 'pending') {
+      dispatch(deleteBooking(booking_id));
+      showCustomSnackbar('Your booking was deleted!', 'info');
+      setTimeout(() => navigate('/bookings'), 2000)
+    } else {
+      dispatch(updateBookingStatus({ id: booking.booking_id, status: 'cancelled' }))
+      showCustomSnackbar('Your booking was cancelled!', 'info');
+    }
+    setWantsToCancel(false)
+  };
+
+  const handleBrokenImg = (e: React.SyntheticEvent<HTMLImageElement, Event>) => {
+    (e.target as HTMLImageElement).src = '/src/assets/broken_img.png';
+  }
+
 
   useEffect(() => {
     if (!booking_id) {
@@ -19,21 +62,33 @@ function SingleBooking() {
   useEffect(() => {
     if (!booking_id) return;
     if (!booking_selector) dispatch(fetchBooking(booking_id));
-      // eslint-disable-next-line react-hooks/exhaustive-deps
+    // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [dispatch]);
 
-  if (!booking_selector) return (
-    <Stack sx={{ textAlign: 'center' }}><Typography variant='heading_secondary_bold'>No booking found!</Typography></Stack>
-  )
+  if (loading)
+    return (
+      <Box sx={{ mx: 'auto', width: 'fit-content' }}>
+        <Spinner />
+      </Box>
+    );
 
-  const { items, booking } = booking_selector
+  if (!booking_selector)
+    return (
+      <Stack sx={{ textAlign: 'center' }}>
+        <Typography variant="heading_secondary_bold">
+          No booking found!
+        </Typography>
+      </Stack>
+    );
+
+  const { items, booking } = booking_selector;
 
   return (
-    <Box maxWidth={900} sx={{ m: 'auto' }}>
+    <Box maxWidth={900} sx={{ m: 'auto', p: 2 }}>
       <Typography variant="heading_secondary_bold">
         Booking ID: {booking.booking_id.substring(24).toUpperCase()}
       </Typography>
-      <Typography variant='body2'>{`${items[0].start_date} - ${items[0].end_date}`}</Typography>
+      <Typography variant="body2">{`${items[0].start_date} - ${items[0].end_date}`}</Typography>
 
       <Box>
         <TableContainer sx={{ pt: 2 }}>
@@ -46,14 +101,20 @@ function SingleBooking() {
             </TableHead>
             <TableBody>
               {items.map((item) => (
-                <TableRow key={item.item_id}>
+                <TableRow sx={{ height: 130 }} key={item.item_id}>
                   <TableCell>
-                    <Stack direction='row' gap={1}>
-                      <img style={{ maxWidth: 78, borderRadius: '14px' }} src={item.image_path ?? '/src/assets/broken_img.png'} />
-                      <Stack>
-                        <Typography>{item.item_name}</Typography>
+                    <Link href={`/items/${item.item_id}`} sx={{ textDecoration: 'none' }}>
+                      <Stack direction="row" gap={1}>
+                        <img
+                          onError={handleBrokenImg}
+                          style={{ maxWidth: 78, borderRadius: '14px' }}
+                          src={item.image_path ?? '/src/assets/broken_img.png'}
+                        />
+                        <Stack>
+                          <Typography>{item.item_name}</Typography>
+                        </Stack>
                       </Stack>
-                    </Stack>
+                    </Link>
                   </TableCell>
                   <TableCell>
                     <Typography>{item.quantity}</Typography>
@@ -63,6 +124,47 @@ function SingleBooking() {
             </TableBody>
           </Table>
         </TableContainer>
+        {
+          // Only allow dates that are after todays date to be cancelled
+          // And booking that haven't been cancelled
+          items[0].start_date >
+          new Date().toLocaleDateString().slice(0, 10) &&
+          booking.status !== 'cancelled' && (
+            <Button
+              onClick={() => setWantsToCancel(true)}
+              size="small"
+              variant="outlined_rounded"
+              sx={{
+                mt: 2,
+                display: 'block',
+                ml: 'auto',
+                height: 'fit-content',
+                width: 'fit-content',
+                padding: '6px 40px',
+              }}
+            >
+              Cancel
+            </Button>
+          )
+        }
+        {wantsToCancel &&
+          <Dialog
+            open={wantsToCancel ? true : false}
+            onClose={() => setWantsToCancel(false)}
+            aria-labelledby="alert-dialog-title"
+            aria-describedby="alert-dialog-description"
+          >
+            <DialogTitle id="alert-dialog-title">
+              Are you sure you want to {booking.status === 'pending' ? 'delete' : 'cancel'} your booking?
+            </DialogTitle>
+            <DialogActions>
+              <Button variant='outlined' onClick={() => handleCancel(booking.booking_id)}>
+                Yes, I'm sure
+              </Button>
+              <Button variant='contained' color='secondary' autoFocus onClick={() => setWantsToCancel(false)}>No thanks</Button>
+            </DialogActions>
+          </Dialog>
+        }
       </Box>
     </Box>
   );

--- a/frontend/src/components/Booking.tsx
+++ b/frontend/src/components/Booking.tsx
@@ -34,6 +34,7 @@ function SingleBooking() {
   const booking_selector = useAppSelector(selectBooking);
   const loading = useAppSelector(selectBookingsLoading);
   const [wantsToCancel, setWantsToCancel] = useState(false)
+  const NON_CANCELLABLE = ['cancelled', 'rejected']
 
   /* ─────────────────── handlers ─────────────────── */
   const handleCancel = (booking_id: string) => {
@@ -126,10 +127,10 @@ function SingleBooking() {
         </TableContainer>
         {
           // Only allow dates that are after todays date to be cancelled
-          // And booking that haven't been cancelled
+          // And booking that haven't been cancelled or rejected
           items[0].start_date >
           new Date().toLocaleDateString().slice(0, 10) &&
-          booking.status !== 'cancelled' && (
+          !NON_CANCELLABLE.includes(booking.status) && (
             <Button
               onClick={() => setWantsToCancel(true)}
               size="small"

--- a/frontend/src/components/User/ItemDetail.tsx
+++ b/frontend/src/components/User/ItemDetail.tsx
@@ -137,7 +137,7 @@ const ItemDetail: React.FC = () => {
               {item?.description || 'Description not available.'}
             </Typography>
 
-            <Typography variant="h6" component="div" sx={{ mt: 2 }}>
+            <Typography variant="subheading" component="div" sx={{ mt: 2 }}>
               Select dates
             </Typography>
             <Provider

--- a/frontend/src/components/User/UserBookings.tsx
+++ b/frontend/src/components/User/UserBookings.tsx
@@ -15,14 +15,24 @@ import {
   IconButton,
   Tooltip,
   useTheme,
+  Dialog,
+  DialogTitle,
+  DialogActions,
+  Button,
+  Link
 } from '@mui/material';
 import CloseIcon from '@mui/icons-material/Close';
 import { useAppDispatch, useAppSelector } from '../../store/hooks';
 import { RootState } from '../../store/store';
 import { BookingWithRes, Item } from '../../types/types';
 import { useAuth } from '../../hooks/useAuth';
-import { useEffect } from 'react';
-import { deleteBooking, fetchUserBookings, selectUserBookings } from '../../slices/bookingsSlice';
+import { useEffect, useState } from 'react';
+import {
+  deleteBooking,
+  fetchUserBookings,
+  selectUserBookings,
+  updateBookingStatus,
+} from '../../slices/bookingsSlice';
 import { showCustomSnackbar } from '../CustomSnackbar';
 
 const UserBookings = () => {
@@ -30,25 +40,34 @@ const UserBookings = () => {
   const userId = user?.id;
   const dispatch = useAppDispatch();
   const theme = useTheme();
-
+  const [wantsToCancel, setWantsToCancel] = useState<BookingWithRes | null>(null);
 
   /* ─────────────────── handlers ─────────────────── */
-  const handleCancel = (bookingId: string) => {
-    dispatch(deleteBooking(bookingId)).then(() =>
+  const handleCancel = (booking: BookingWithRes) => {
+    if (booking.status === 'pending') {
+      dispatch(deleteBooking(booking.booking_id));
+      showCustomSnackbar('Your booking was deleted!', 'info');
+    } else {
+      dispatch(updateBookingStatus({ id: booking.booking_id, status: 'cancelled' }))
+      showCustomSnackbar('Your booking was cancelled!', 'info');
+    }
 
-      showCustomSnackbar('Booking cancelled', 'info'));
+    setWantsToCancel(null)
+    setTimeout(() => {
+      if (user) dispatch(fetchUserBookings(user?.id))
+    }, 10)
   };
 
   /* ─────────────────── selectors ─────────────────── */
-  const {
-    loading,
-    error,
-  } = useAppSelector((state: RootState) => state.bookings);
+  const { loading, error } = useAppSelector(
+    (state: RootState) => state.bookings,
+  );
 
   // Use selector for user bookings
   const bookings = useAppSelector(selectUserBookings) as BookingWithRes[];
-  const sortedBookings = [...bookings].sort((a, b) =>
-    new Date(b.created_at).getTime() - new Date(a.created_at).getTime()
+  const sortedBookings = [...bookings].sort(
+    (a, b) =>
+      new Date(b.created_at).getTime() - new Date(a.created_at).getTime(),
   );
 
   /* ─────────────────── side-effects ─────────────────── */
@@ -79,7 +98,12 @@ const UserBookings = () => {
   return (
     <Container>
       <Box sx={{ maxWidth: 900, mx: 'auto', mt: 4 }}>
-        <Typography variant="heading_secondary" component='h1' gutterBottom sx={{ mb: 2 }}>
+        <Typography
+          variant="heading_secondary"
+          component="h1"
+          gutterBottom
+          sx={{ mb: 2 }}
+        >
           Your Bookings
         </Typography>
 
@@ -88,98 +112,141 @@ const UserBookings = () => {
         ) : (
           <Stack spacing={4}>
             {sortedBookings.map((booking) => (
-              <Box key={booking.booking_id} sx={{ p: 3, pb: 4 }} border={'1px solid #E2E2E2'}>
-                {/* booking header */}
-                <Stack justifyContent={'space-between'} sx={{ mb: 2, flexDirection: { xs: 'column', md: 'row' }, gap: { xs: 2, md: 0 } }}>
-                  <Stack sx={{ gap: '2px' }}>
-                    <Typography
-                      variant="subheading"
-                      fontWeight={600}
-                    >
-                      Booking&nbsp;ID:&nbsp;{booking.booking_id.slice(-12).toUpperCase()}
-                    </Typography>
-                    <Typography
-                      variant="body3"
-                      fontWeight={500}
-                      fontSize={14}
-                    >Created at{' '}
-                      {new Date(booking.created_at).toLocaleString()}
-                    </Typography>
-                  </Stack>
-
-                  <Box>
-                    <Chip
-                      sx={{
-                        mr: 1,
-                        ...(booking.status === 'pending'
-                          ? { bgcolor: '#FFCA28', color: theme.palette.getContrastText('#FFCA28') }
-                          : {}),
-                      }}
-                      label={booking.status}
-                      color={
-                        booking.status === 'approved'
-                          ? 'success'
-                          : booking.status === 'pending'
-                            ? 'warning'
-                            : booking.status === 'rejected'
-                              ? 'error'
-                              : 'default'
-                      }
-                    />
-                    <Tooltip title="Cancel booking">
-                      <IconButton
-                        size="small"
-                        onClick={() => handleCancel(booking.booking_id)}
-                      >
-                        <CloseIcon fontSize="small" />
-                      </IconButton>
-                    </Tooltip>
-                  </Box>
-
-                </Stack>
-                <TableContainer>
-                  <Table
+              <Link key={booking.booking_id} href={`/bookings/${booking.booking_id}`} sx={{ textDecoration: 'none' }}>
+                <Box
+                  sx={{ p: 3, pb: 4 }}
+                  border={'1px solid #E2E2E2'}
+                >
+                  {/* booking header */}
+                  <Stack
+                    justifyContent={'space-between'}
                     sx={{
-                      // Remove bottom border (divider) on the last row
-                      '& .MuiTableRow-root:last-child td, & .MuiTableRow-root:last-child th': {
-                        borderBottom: 0,
-                      },
+                      mb: 2,
+                      flexDirection: { xs: 'column', md: 'row' },
+                      gap: { xs: 2, md: 0 },
                     }}
                   >
-                    <TableHead>
-                      <TableRow>
-                        <TableCell align='left' sx={{ pl: 0 }}>Item</TableCell>
-                        <TableCell>Start Date</TableCell>
-                        <TableCell>End Date</TableCell>
-                        <TableCell align='center'>Quantity</TableCell>
-                      </TableRow>
-                    </TableHead>
-                    <TableBody>
-                      {booking.reservations.map((res) => (
-                        <TableRow key={res.reservation_id}>
-                          <TableCell align='left' sx={{ pl: 0 }}>
-                            {items.find((i) => i.item_id === res.item_id)?.item_name ?? res.item_id}
+                    <Stack sx={{ gap: '2px' }}>
+                      <Typography variant="subheading" fontWeight={600}>
+                        Booking&nbsp;ID:&nbsp;
+                        {booking.booking_id.slice(-12).toUpperCase()}
+                      </Typography>
+                      <Typography variant="body3" fontWeight={500} fontSize={14}>
+                        Created at {new Date(booking.created_at).toLocaleString()}
+                      </Typography>
+                    </Stack>
+
+                    <Box>
+                      <Chip
+                        sx={{
+                          mr: 1,
+                          ...(booking.status === 'pending'
+                            ? {
+                              bgcolor: '#FFCA28',
+                              color: theme.palette.getContrastText('#FFCA28'),
+                            }
+                            : {}),
+                        }}
+                        label={booking.status}
+                        color={
+                          booking.status === 'approved'
+                            ? 'success'
+                            : booking.status === 'pending'
+                              ? 'warning'
+                              : booking.status === 'rejected'
+                                ? 'error'
+                                : booking.status === 'cancelled'
+                                  ? 'warning'
+                                  : 'default'
+                        }
+                      />
+                      {
+                        // Only allow dates that are after todays date to be cancelled
+                        // And booking that haven't been cancelled
+                        booking.reservations[0].start_date >
+                        new Date().toLocaleDateString().slice(0, 10) && booking.status !== 'cancelled'
+                        && (
+                          <Tooltip title="Cancel booking">
+                            <IconButton
+                              onClick={(e) => {
+                                e.preventDefault()
+                                setWantsToCancel(booking)
+                              }}
+                              size="small"
+                            >
+                              <CloseIcon fontSize="small" />
+                            </IconButton>
+                          </Tooltip>
+                        )
+                      }
+
+                    </Box>
+                  </Stack>
+
+                  <TableContainer>
+                    <Table
+                      sx={{
+                        // Remove bottom border (divider) on the last row
+                        '& .MuiTableRow-root:last-child td, & .MuiTableRow-root:last-child th':
+                        {
+                          borderBottom: 0,
+                        },
+                      }}
+                    >
+                      <TableHead>
+                        <TableRow>
+                          <TableCell align="left" sx={{ pl: 0 }}>
+                            Item
                           </TableCell>
-                          <TableCell>
-                            {new Date(res.start_date).toLocaleDateString()}
-                          </TableCell>
-                          <TableCell>
-                            {new Date(res.end_date).toLocaleDateString()}
-                          </TableCell>
-                          <TableCell align='center'>{res.quantity}</TableCell>
+                          <TableCell>Start Date</TableCell>
+                          <TableCell>End Date</TableCell>
+                          <TableCell align="center">Quantity</TableCell>
                         </TableRow>
-                      ))}
-                    </TableBody>
-                  </Table>
-                </TableContainer>
-              </Box>
+                      </TableHead>
+                      <TableBody>
+                        {booking.reservations.map((res) => (
+                          <TableRow key={res.reservation_id}>
+                            <TableCell align="left" sx={{ pl: 0 }}>
+                              {items.find((i) => i.item_id === res.item_id)
+                                ?.item_name ?? res.item_id}
+                            </TableCell>
+                            <TableCell>
+                              {new Date(res.start_date).toLocaleDateString()}
+                            </TableCell>
+                            <TableCell>
+                              {new Date(res.end_date).toLocaleDateString()}
+                            </TableCell>
+                            <TableCell align="center">{res.quantity}</TableCell>
+                          </TableRow>
+                        ))}
+                      </TableBody>
+                    </Table>
+                  </TableContainer>
+                </Box>
+              </Link>
             ))}
           </Stack>
-        )
-        }
-      </Box >
+        )}
+      </Box>
+      {wantsToCancel &&
+        <Dialog
+          open={wantsToCancel ? true : false}
+          onClose={() => setWantsToCancel(null)}
+          aria-labelledby="alert-dialog-title"
+          aria-describedby="alert-dialog-description"
+        >
+          <DialogTitle id="alert-dialog-title">
+            Are you sure you want to cancel your booking?
+          </DialogTitle>
+          <DialogActions>
+            <Button variant='outlined' onClick={() => handleCancel(wantsToCancel)}>
+              Yes, I'm sure
+            </Button>
+            <Button variant='contained' color='secondary' autoFocus onClick={() => setWantsToCancel(null)}>No thanks</Button>
+          </DialogActions>
+        </Dialog>
+      }
     </Container>
-
   );
 };
 

--- a/frontend/src/components/User/UserBookings.tsx
+++ b/frontend/src/components/User/UserBookings.tsx
@@ -41,6 +41,7 @@ const UserBookings = () => {
   const dispatch = useAppDispatch();
   const theme = useTheme();
   const [wantsToCancel, setWantsToCancel] = useState<BookingWithRes | null>(null);
+  const NON_CANCELLABLE = ['rejected', 'cancelled']
 
   /* ─────────────────── handlers ─────────────────── */
   const handleCancel = (booking: BookingWithRes) => {
@@ -164,7 +165,7 @@ const UserBookings = () => {
                         // Only allow dates that are after todays date to be cancelled
                         // And booking that haven't been cancelled
                         booking.reservations[0].start_date >
-                        new Date().toLocaleDateString().slice(0, 10) && booking.status !== 'cancelled'
+                        new Date().toLocaleDateString().slice(0, 10) && !NON_CANCELLABLE.includes(booking.status)
                         && (
                           <Tooltip title="Cancel booking">
                             <IconButton

--- a/frontend/src/pages/Cart.tsx
+++ b/frontend/src/pages/Cart.tsx
@@ -27,7 +27,7 @@ import {
 import InfoOutlineIcon from '@mui/icons-material/InfoOutline';
 import { addBooking, fetchUserBookings } from '../slices/bookingsSlice';
 import { useAuth } from '../hooks/useAuth';
-import { Link } from 'react-router-dom';
+import { Link, useNavigate } from 'react-router-dom';
 import { showCustomSnackbar } from '../components/CustomSnackbar';
 import { store } from '../store/store';
 import { checkAvailabilityForItemOnDates } from '../selectors/availabilitySelector';
@@ -48,6 +48,7 @@ function Cart() {
 	const [qtyCheckErrors] = useState<Record<string, string>>({});
 	const [incorrectCart, setIncorrectCart] = useState(false);
 	const [localCart, setLocalCart] = useState<ItemWithQuantity[]>([]);
+	const navigate = useNavigate()
 
 	useEffect(() => {
 		updateRangeWithSelectedRange();
@@ -227,7 +228,6 @@ function Cart() {
 	const handleBrokenImg = (
 		e: React.SyntheticEvent<HTMLImageElement, Event>,
 	) => {
-		console.log('handle error');
 		(e.target as HTMLImageElement).src = '/src/assets/broken_img.png';
 	};
 
@@ -241,9 +241,12 @@ function Cart() {
 		if (addBooking.rejected.match(resultAction)) {
 			showCustomSnackbar(resultAction.payload ?? 'unknown error', 'error');
 		} else {
-			showCustomSnackbar('Booking created', 'success');
+			showCustomSnackbar('Your booking has been created!', 'success');
 			dispatch(emptyCart());
 			dispatch(fetchUserBookings(user.id));
+
+			// Navigate to new booking
+			navigate(`/bookings/${resultAction.payload.booking_id}`)
 		}
 	};
 

--- a/frontend/src/pages/Cart.tsx
+++ b/frontend/src/pages/Cart.tsx
@@ -11,6 +11,7 @@ import {
 	TableHead,
 	TableRow,
 	Typography,
+	Link as MUILink
 } from '@mui/material';
 import RemoveIcon from '@mui/icons-material/Remove';
 import CloseIcon from '@mui/icons-material/Close';
@@ -291,22 +292,24 @@ function Cart() {
 										}}
 									>
 										<TableCell>
-											<Stack direction={'row'} sx={{ gap: '21px' }}>
-												<CardMedia
-													component="img"
-													image={
-														item.image_path || '/src/assets/broken_img.png'
-													}
-													onError={handleBrokenImg}
-													style={{ width: 78, borderRadius: 14 }}
-												/>
-												<Stack sx={{ maxWidth: 186 }}>
-													<Typography>{item.item_name}</Typography>
-													{incorrectCart &&
-														<Typography color="error">{qtyCheckErrors[item.item_id]}</Typography>
-													}
+											<MUILink href={`/items/${item.item_id}`} sx={{ textDecoration: 'none' }}>
+												<Stack direction={'row'} sx={{ gap: '21px' }}>
+													<CardMedia
+														component="img"
+														image={
+															item.image_path || '/src/assets/broken_img.png'
+														}
+														onError={handleBrokenImg}
+														style={{ width: 78, borderRadius: 14 }}
+													/>
+													<Stack sx={{ maxWidth: 186 }}>
+														<Typography>{item.item_name}</Typography>
+														{incorrectCart &&
+															<Typography color="error">{qtyCheckErrors[item.item_id]}</Typography>
+														}
+													</Stack>
 												</Stack>
-											</Stack>
+											</MUILink>
 										</TableCell>
 										<TableCell align="center">
 											<ButtonGroup

--- a/frontend/src/slices/bookingsSlice.ts
+++ b/frontend/src/slices/bookingsSlice.ts
@@ -77,12 +77,12 @@ export const fetchUserBookings = createAsyncThunk<
 /**
  * Change the status of a booking
  * @param id - The ID of the booking to change
- * @param status - The new status to set for the booking(either "approved" or "rejected")
+ * @param status - The new status to set for the booking(either "approved", "rejected" or "cancelled")
  * @returns A promise that resolves to the updated booking
  */
 export const updateBookingStatus = createAsyncThunk<
   Booking,
-  { id: string; status: 'approved' | 'rejected' },
+  { id: string; status: 'approved' | 'rejected' | 'cancelled'},
   { rejectValue: string }
 >(
   'bookings/updateBookingStatus',
@@ -106,13 +106,13 @@ export const updateBookingStatus = createAsyncThunk<
 );
 
 export const addBooking = createAsyncThunk<
-  Booking,
+  { booking_id: string; status: string },
   object,
   { rejectValue: string }
 >('bookings/rpc', async (newBooking, { rejectWithValue }) => {
   try {
     const response = await bookingsApi.createBooking(newBooking);
-    return response.data;
+    return response;
   } catch (error: unknown) {
     if (axios.isAxiosError<{ message: string }>(error)) {
       return rejectWithValue(error.response?.data?.message ?? 'Network error');
@@ -156,17 +156,16 @@ export const bookingsSlice = createSlice({
       state.loading = true;
     });
     builder.addCase(fetchUserBookings.fulfilled, (state, action) => {
-      state.loading = false;
       state.userBookings = action.payload;
-    });
-    builder.addCase(fetchUserBookings.rejected, (state, action) => {
       state.loading = false;
-      state.error = action.payload ?? 'Could not fetch user bookings';
+    });
+    builder.addCase(fetchUserBookings.rejected, (state) => {
+      state.error = 'Could not fetch user bookings';
+      state.loading = false;
     });
 
-    builder.addCase(addBooking.fulfilled, (state, action) => {
+    builder.addCase(addBooking.fulfilled, (state) => {
       localStorage.removeItem('savedCart');
-      state.bookings.push(action.payload);
       state.loading = false;
     });
     builder.addCase(addBooking.rejected, (state, action) => {

--- a/frontend/src/theme/theme.ts
+++ b/frontend/src/theme/theme.ts
@@ -239,5 +239,40 @@ export const createAppTheme = () =>
           },
         },
       },
+      MuiDialogTitle: {
+        styleOverrides: {
+          root: {
+            fontSize: 21,
+            fontWeight: 400,
+            fontFamily: 'Oxygen, sans-serif',
+            color: '#282828',
+            padding: 0,
+          }
+        }
+      },
+      MuiDialog: {
+        styleOverrides: {
+          root: {
+            '& .MuiBackdrop-root': {
+              backgroundColor: 'rgba(0,0,0,0.1)',
+              boxShadow: 'none', filter: 'none',
+              borderRadius: '3px', 
+            },
+            '& .MuiPaper-root': {
+              boxShadow: 'none', filter: 'none', padding: '2rem',
+              gap: '2rem', maxWidth: 440,
+            }
+
+          }
+        }
+      },
+      MuiDialogActions: {
+        styleOverrides: {
+          root: {
+            padding: 0,
+            justifyContent: 'start',
+          }
+        }
+      }
     },
   });


### PR DESCRIPTION
# Summary
Users now have the possibility to `cancel` an already approved booking or `delete` a pending booking. Cancelled bookings are still kept in the database while deleted bookings are >deleted<

## Major changes
- User can delete/cancel booking in `<UserBookings />`
- User can delete/cancel booking in `<Booking />`

## Minor changes
### **Navigation**
- Added navigation to a single booking from `UserBookings` by pressing an individual booking
- Added navigation to single item from `Cart` and `Booking`

### **Etc**
- Added loading states (with our cute spinner) to `<Booking />`
- Added `cancelled` as a status type to `updateBookingStatus` in our booking API

### 🐛  **Bug fixes**
- We had a bug in `bookingsApi` where `createBooking` returned the response of the api call, rather than the api call itself like the rest of the api calls do.
- Fixed broken images not displaying the fallback in several components

![Skärmbild 2025-05-08 230345](https://github.com/user-attachments/assets/ba84cd66-fffe-4dec-b8a8-1a405c0f985a)
